### PR TITLE
Marshmallow 3 Compatibility

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,23 +10,44 @@ test-2.7:
     - pip install tox
     - tox -e py27
 
-test-3.4:
+test-3.4-marshmallow-2:
   image: python:3.4
   stage: test
   script:
     - pip install tox
-    - tox -e py34
+    - tox -e py34-marshmallow2
 
-test-3.6:
+test-3.4-marshmallow-3:
+  image: python:3.4
+  stage: test
+  script:
+    - pip install tox
+    - tox -e py34-marshmallow3
+
+test-3.6-marshmallow-2:
   image: python:3.6
   stage: test
   script:
     - pip install tox
-    - tox -e py36
+    - tox -e py36-marshmallow2
 
-test-3.7:
+test-3.6-marshmallow-2:
+  image: python:3.6
+  stage: test
+  script:
+    - pip install tox
+    - tox -e py36-marshmallow3
+
+test-3.7-marshmallow-2:
   image: python:3.7
   stage: test
   script:
     - pip install tox
-    - tox -e py37
+    - tox -e py37-marshmallow2
+
+test-3.7-marshmallow-3:
+  image: python:3.7
+  stage: test
+  script:
+    - pip install tox
+    - tox -e py37-marshmallow3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,19 +10,26 @@ test-2.7:
     - pip install tox
     - tox -e py27
 
-test-3.4-marshmallow-2:
+test-3.4:
   image: python:3.4
   stage: test
   script:
     - pip install tox
-    - tox -e py34-marshmallow2
+    - tox -e py34
 
-test-3.4-marshmallow-3:
-  image: python:3.4
+test-3.5-marshmallow-2:
+  image: python:3.5
   stage: test
   script:
     - pip install tox
-    - tox -e py34-marshmallow3
+    - tox -e py35-marshmallow2
+
+test-3.5-marshmallow-3:
+  image: python:3.5
+  stage: test
+  script:
+    - pip install tox
+    - tox -e py35-marshmallow3
 
 test-3.6-marshmallow-2:
   image: python:3.6

--- a/falcon_marshmallow/_version.py
+++ b/falcon_marshmallow/_version.py
@@ -9,8 +9,11 @@ and also set as the __version__ attribute for the package.
 ``setup.py egg_info`` command when creating distributions.
 """
 from __future__ import (
-    absolute_import, division, print_function, unicode_literals
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
 )
 
-__version_info__ = (0, 2, 0)
-__version__ = '.'.join([str(ver) for ver in __version_info__])
+__version_info__ = (0, 3, 0)
+__version__ = ".".join([str(ver) for ver in __version_info__])

--- a/falcon_marshmallow/middleware.py
+++ b/falcon_marshmallow/middleware.py
@@ -437,4 +437,3 @@ class Marshmallow:
                         "bug."
                     ),
                 )
-

--- a/falcon_marshmallow/middleware.py
+++ b/falcon_marshmallow/middleware.py
@@ -331,6 +331,10 @@ class Marshmallow:
                     raise HTTPUnprocessableEntity(
                         description=self._json.dumps(exc.messages)
                     )
+                except Exception as exc:
+                    raise HTTPUnprocessableEntity(
+                        description=self._json.dumps({"error": exc})
+                    )
 
             req.context[self._req_key] = data
 
@@ -408,6 +412,15 @@ class Marshmallow:
                     raise HTTPInternalServerError(
                         title="Could not serialize response",
                         description=self._json.dumps(exc.messages),
+                    )
+                except Exception as exc:
+                    # For some reason Marshmallow does not intercept e.g.
+                    # ValueErrors and throw a ValidationError when a value
+                    # is of the wrong type, instead letting the excpetion
+                    # percolate up.
+                    raise HTTPInternalServerError(
+                        title="Could not serialize response",
+                        description=self._json.dumps({"error": str(exc)}),
                     )
 
             resp.body = data

--- a/falcon_marshmallow/middleware.py
+++ b/falcon_marshmallow/middleware.py
@@ -5,13 +5,18 @@ Middleware class(es) for Falcon-Marshmallow
 
 # Std lib
 from __future__ import (
-    absolute_import, division, print_function, unicode_literals
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
 )
 import logging
 from typing import Container, Optional
 
 # Third party
+import marshmallow
 import simplejson
+
 from falcon import Request, Response
 from falcon.errors import (
     HTTPBadRequest,
@@ -20,14 +25,15 @@ from falcon.errors import (
     HTTPUnprocessableEntity,
     HTTPUnsupportedMediaType,
 )
-from marshmallow import Schema
+from marshmallow import Schema, ValidationError
 
 
 log = logging.getLogger(__name__)
 
 
-JSON_CONTENT_REQUIRED_METHODS = ('POST', 'PUT', 'PATCH')
-CONTENT_KEY = 'content'
+JSON_CONTENT_REQUIRED_METHODS = ("POST", "PUT", "PATCH")
+CONTENT_KEY = "content"
+MARSHMALLOW_2 = marshmallow.__version_info__ < (3,)
 
 
 def get_stashed_content(req):
@@ -62,7 +68,7 @@ class JSONEnforcer:
             which "application/json" should be required as a
             Content-Type header
         """
-        log.debug('JSONEnforcer.__init__(%s)', required_methods)
+        log.debug("JSONEnforcer.__init__(%s)", required_methods)
         self._methods = required_methods
 
     def process_request(self, req, resp):
@@ -78,19 +84,21 @@ class JSONEnforcer:
             specified by "required_methods" does not specify a
             content-type of "application/json"
         """
-        log.debug('JSONEnforcer.process_request(%s, %s)', req, resp)
+        log.debug("JSONEnforcer.process_request(%s, %s)", req, resp)
         if not req.client_accepts_json:
             raise HTTPNotAcceptable(
                 description=(
-                    'This server only supports responses encoded as JSON. '
+                    "This server only supports responses encoded as JSON. "
                     'Please update your "Accept" header to include '
                     '"application/json".'
                 )
             )
 
         if req.method in JSON_CONTENT_REQUIRED_METHODS:
-            if (req.content_type is None or
-                    'application/json' not in req.content_type):
+            if (
+                req.content_type is None
+                or "application/json" not in req.content_type
+            ):
                 raise HTTPUnsupportedMediaType(
                     description=(
                         '%s requests must have "application/json" in their '
@@ -115,7 +123,7 @@ class EmptyRequestDropper:
         :raises HTTPBadRequest: if the request has content length with
             an empty body
         """
-        log.debug('EmptyRequestDropper.process_request(%s, %s)', req, resp)
+        log.debug("EmptyRequestDropper.process_request(%s, %s)", req, resp)
         if req.content_length in (None, 0):
             return
 
@@ -125,7 +133,7 @@ class EmptyRequestDropper:
         if not content:
             raise HTTPBadRequest(
                 description=(
-                    'Empty response body. A valid JSON document is required.'
+                    "Empty response body. A valid JSON document is required."
                 )
             )
 
@@ -133,8 +141,13 @@ class EmptyRequestDropper:
 class Marshmallow:
     """Attempt to deserialize objects with any available schemas"""
 
-    def __init__(self, req_key='json', resp_key='result', force_json=True,
-                 json_module=simplejson):
+    def __init__(
+        self,
+        req_key="json",
+        resp_key="result",
+        force_json=True,
+        json_module=simplejson,
+    ):
         # type: (str, str, bool, type(json)) -> None
         """Instantiate the middleware object
 
@@ -160,8 +173,11 @@ class Marshmallow:
 
         """
         log.debug(
-            'Marshmallow.__init__(%s, %s, %s, %s)',
-            req_key, resp_key, force_json, json_module
+            "Marshmallow.__init__(%s, %s, %s, %s)",
+            req_key,
+            resp_key,
+            force_json,
+            json_module,
         )
         self._req_key = req_key
         self._resp_key = resp_key
@@ -195,16 +211,18 @@ class Marshmallow:
             ``process_response`` or ``process_resource``
         """
         log.debug(
-            'Marshmallow._get_specific_schema(%s, %s, %s)',
-            resource, method, msg_type
+            "Marshmallow._get_specific_schema(%s, %s, %s)",
+            resource,
+            method,
+            msg_type,
         )
 
-        sch_name = '%s_%s_schema' % (method.lower(), msg_type)
+        sch_name = "%s_%s_schema" % (method.lower(), msg_type)
         specific_schema = getattr(resource, sch_name, None)
         if specific_schema is not None:
             return specific_schema
 
-        sch_name = '%s_schema' % method.lower()
+        sch_name = "%s_schema" % method.lower()
         specific_schema = getattr(resource, sch_name, None)
         return specific_schema
 
@@ -238,15 +256,12 @@ class Marshmallow:
             ``process_response`` or ``process_resource``
         """
         log.debug(
-            'Marshmallow._get_schema(%s, %s, %s)',
-            resource, method, msg_type
+            "Marshmallow._get_schema(%s, %s, %s)", resource, method, msg_type
         )
-        specific_schema = cls._get_specific_schema(
-            resource, method, msg_type
-        )
+        specific_schema = cls._get_specific_schema(resource, method, msg_type)
         if specific_schema is not None:
             return specific_schema
-        return getattr(resource, 'schema', None)
+        return getattr(resource, "schema", None)
 
     def process_resource(self, req, resp, resource, params):
         # type: (Request, Response, object, dict) -> None
@@ -274,35 +289,48 @@ class Marshmallow:
             deserialized or decoded
         """
         log.debug(
-            'Marshmallow.process_resource(%s, %s, %s, %s)',
-            req, resp, resource, params
+            "Marshmallow.process_resource(%s, %s, %s, %s)",
+            req,
+            resp,
+            resource,
+            params,
         )
         if req.content_length in (None, 0):
             return
 
-        sch = self._get_schema(resource, req.method, 'request')
+        sch = self._get_schema(resource, req.method, "request")
 
         if sch is not None:
             if not isinstance(sch, Schema):
                 raise TypeError(
-                    'The schema and <method>_schema properties of a resource '
-                    'must be instantiated Marshmallow schemas.'
+                    "The schema and <method>_schema properties of a resource "
+                    "must be instantiated Marshmallow schemas."
                 )
 
             try:
                 body = get_stashed_content(req)
                 parsed = self._json.loads(body)
             except UnicodeDecodeError:
-                raise HTTPBadRequest('Body was not encoded as UTF-8')
+                raise HTTPBadRequest("Body was not encoded as UTF-8")
             except self._json.JSONDecodeError:
-                raise HTTPBadRequest('Request must be valid JSON')
+                raise HTTPBadRequest("Request must be valid JSON")
 
-            data, errors = sch.load(parsed)
+            if MARSHMALLOW_2:
+                data, errors = sch.load(parsed)
 
-            if errors:
-                raise HTTPUnprocessableEntity(
-                    description=self._json.dumps(errors)
-                )
+                if errors:
+                    raise HTTPUnprocessableEntity(
+                        description=self._json.dumps(errors)
+                    )
+            else:
+                # Marshmallow 3 or higher raises a ValidationError
+                # instead of returning a (data, errors) tuple.
+                try:
+                    data = sch.load(parsed)
+                except ValidationError as exc:
+                    raise HTTPUnprocessableEntity(
+                        description=self._json.dumps(exc.messages)
+                    )
 
             req.context[self._req_key] = data
 
@@ -314,9 +342,9 @@ class Marshmallow:
             except (ValueError, UnicodeDecodeError):
                 raise HTTPBadRequest(
                     description=(
-                        'Could not decode the request body, either because '
-                        'it was not valid JSON or because it was not encoded '
-                        'as UTF-8.'
+                        "Could not decode the request body, either because "
+                        "it was not valid JSON or because it was not encoded "
+                        "as UTF-8."
                     )
                 )
 
@@ -345,28 +373,42 @@ class Marshmallow:
             in the ``req.context`` object cannot be serialized
         """
         log.debug(
-            'Marshmallow.process_response(%s, %s, %s, %s)',
-            req, resp, resource, req_succeeded
+            "Marshmallow.process_response(%s, %s, %s, %s)",
+            req,
+            resp,
+            resource,
+            req_succeeded,
         )
         if self._resp_key not in req.context:
             return
 
-        sch = self._get_schema(resource, req.method, 'response')
+        sch = self._get_schema(resource, req.method, "response")
 
         if sch is not None:
             if not isinstance(sch, Schema):
                 raise TypeError(
-                    'The schema and <method>_schema properties of a resource '
-                    'must be instantiated Marshmallow schemas.'
+                    "The schema and <method>_schema properties of a resource "
+                    "must be instantiated Marshmallow schemas."
                 )
 
-            data, errors = sch.dumps(req.context[self._resp_key])
+            if MARSHMALLOW_2:
+                data, errors = sch.dumps(req.context[self._resp_key])
 
-            if errors:
-                raise HTTPInternalServerError(
-                    title='Could not serialize response',
-                    description=self._json.dumps(errors)
-                )
+                if errors:
+                    raise HTTPInternalServerError(
+                        title="Could not serialize response",
+                        description=self._json.dumps(errors),
+                    )
+            else:
+                # Marshmallow 3 or higher raises a ValidationError
+                # instead of returning a (data, errors) tuple.
+                try:
+                    data = sch.dumps(req.context[self._resp_key])
+                except ValidationError as exc:
+                    raise HTTPInternalServerError(
+                        title="Could not serialize response",
+                        description=self._json.dumps(exc.messages),
+                    )
 
             resp.body = data
 
@@ -375,10 +417,11 @@ class Marshmallow:
                 resp.body = self._json.dumps(req.context[self._resp_key])
             except TypeError:
                 raise HTTPInternalServerError(
-                    title='Could not serialize response',
+                    title="Could not serialize response",
                     description=(
-                        'The server attempted to serialize an object that '
-                        'cannot be serialized. This is likely a server-side '
-                        'bug.'
-                    )
+                        "The server attempted to serialize an object that "
+                        "cannot be serialized. This is likely a server-side "
+                        "bug."
+                    ),
                 )
+

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,13 @@ from setuptools import setup, find_packages
 from textwrap import dedent
 
 
-NAME = 'falcon_marshmallow'
-URL = 'https://www.github.com/ihiji/falcon-marshmallow'
-AUTHOR = 'Matthew Planchard'
-EMAIL = 'engineering@ihiji.com'
+NAME = "falcon_marshmallow"
+URL = "https://www.github.com/mplanchard/falcon-marshmallow"
+AUTHOR = "Matthew Planchard"
+EMAIL = "msplanchard@gmail.com"
 
 
-SHORT_DESC = 'Automatic Marshmallow (De)serialization in Falcon'
+SHORT_DESC = "Automatic Marshmallow (De)serialization in Falcon"
 
 LONG_DESC = dedent(
     """
@@ -39,76 +39,75 @@ LONG_DESC = dedent(
 )
 
 KEYWORDS = [
-    'ihiji',
-    'falcon',
-    'marshmallow',
-    'marshalling',
-    'middleware',
-    'serialization',
-    'deserialization',
-    'json',
-    'wsgi',
+    "ihiji",
+    "falcon",
+    "marshmallow",
+    "marshalling",
+    "middleware",
+    "serialization",
+    "deserialization",
+    "json",
+    "wsgi",
 ]
 
 
 PACKAGE_DEPENDENCIES = [
-    'falcon',
-    'marshmallow',
-    'simplejson',
+    "falcon",
+    "marshmallow",
+    "simplejson",
     'typing;python_version<"3.5"',
 ]
 
-SETUP_DEPENDENCIES = [
-    'pytest-runner',
-]
+SETUP_DEPENDENCIES = ["pytest-runner"]
 
 TEST_DEPENDENCIES = [
-    'pytest',
-    'pytest-cov',
+    "pytest",
+    "pytest-cov",
     'ipython<6;python_version<"3"',
     'ipython;python_version>="3"',
-    'ipdb',
+    "ipdb",
     'mock;python_version<"3.3"',
 ]
 
 EXTRAS_DEPENDENCIES = {}
 
 
-PACKAGE_EXCLUDE = ['*.tests', '*.tests.*']
+PACKAGE_EXCLUDE = ["*.tests", "*.tests.*"]
 
 # See https://pypi.python.org/pypi?%3Aaction=list_classifiers for all
 # available setup classifiers
 CLASSIFIERS = [
-    'Development Status :: 3 - Alpha',
+    # "Development Status :: 3 - Alpha",
     # 'Development Status :: 4 - Beta',
-    # 'Development Status :: 5 - Production/Stable',
-    'Environment :: Web Environment',
-    'Intended Audience :: Developers',
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Web Environment",
+    "Intended Audience :: Developers",
     # 'License :: Other/Proprietary License',
-    'License :: OSI Approved :: MIT License',
+    "License :: OSI Approved :: MIT License",
     # 'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-    'Natural Language :: English',
-    'Operating System :: POSIX :: Linux',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.4',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: Implementation :: CPython',
-    'Topic :: Internet :: WWW/HTTP :: WSGI :: Middleware',
+    "Natural Language :: English",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 2",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.4",
+    "Programming Language :: Python :: 3.5",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Internet :: WWW/HTTP :: WSGI :: Middleware",
 ]
 
 
-__version__ = '0.0.0'
+__version__ = "0.0.0"
 
 cwd = dirname(realpath(__file__))
 
-with open(join(cwd, '%s/_version.py' % NAME)) as version_file:
+with open(join(cwd, "%s/_version.py" % NAME)) as version_file:
     for line in version_file:
         # This will populate the __version__ and __version_info__ variables
-        if line.startswith('__'):
+        if line.startswith("__"):
             exec(line)
 
 setup(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -384,7 +384,7 @@ class TestExtraMiddleware:
         # We have to forge the content-length header, because if it is
         # made automatically for our empty body, we won't get to the check
         # of the body contents.
-        heads = {'Content-Length': str('20')} if empty_body else None
+        heads = {'Content-Length': str('20')} if empty_body else {}
         body = '' if empty_body else None
 
         res = client.simulate_get(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, {py34,py36,py37}-marshmallow{2,3}
+envlist = py27, py34, {py35,py36,py37}-marshmallow{2,3}
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
-envlist = py27, py34, py36, py37
+envlist = py27, {py34,py36,py37}-marshmallow{2,3}
 
 [testenv]
 deps =
   pytest
   pytest-cov
+  marshmallow2: marshmallow>=2,<3
+  marshmallow3: marshmallow>=3,<4
 
 commands =
   python setup.py test --addopts "{posargs} --cov=falcon_marshmallow"


### PR DESCRIPTION
Resolves #7 and ihiji/falcon-marshmallow#18

Marshmallow 3 changed the return signature of `schema.load` and `schema.dump` operations, returning only the parsed data, and raising a ValidationError in the event of issues. This updates to fork the code depending on the marshmallow version, and to handle each branch appropriately.

There were also some minor updates to the Falcon test client that required updates to the tests. I have also done some autoformatting with `black --line-length=80`.

Tests have been updated to run against marshmallow versions 2 and 3 for platforms that support both, and this bumps the version to `0.3.0`.