### PR TITLE
Add setup flag to distribute type information

### DIFF
--- a/falcon_marshmallow/middleware.py
+++ b/falcon_marshmallow/middleware.py
@@ -10,7 +10,7 @@ from __future__ import (
 )
 import logging
 
-from typing import Any, Container, Optional
+from typing import Any, Iterable, Optional
 
 # Third party
 import marshmallow
@@ -60,7 +60,7 @@ class JSONEnforcer:
     """Enforce that requests are JSON compatible"""
 
     def __init__(self, required_methods=JSON_CONTENT_REQUIRED_METHODS):
-        # type: (Container) -> None
+        # type: (Iterable[str]) -> None
         """Initialize the middleware
 
         :param required_methods: a collection of HTTP methods for
@@ -68,7 +68,7 @@ class JSONEnforcer:
             Content-Type header
         """
         log.debug("JSONEnforcer.__init__(%s)", required_methods)
-        self._methods = required_methods
+        self._methods = tuple(required_methods)
 
     def process_request(self, req, resp):
         # type: (Request, Response) -> None

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ PACKAGE_DEPENDENCIES = [
     'typing;python_version<"3.5"',
 ]
 
+PACKAGE_DATA = {"falcon_marshmallow": ["py.typed"]}
+
 SETUP_DEPENDENCIES = ["pytest-runner"]
 
 TEST_DEPENDENCIES = [


### PR DESCRIPTION
I have just learned about
[PEP-561](https://www.python.org/dev/peps/pep-0561/), which states that
type information specified in a python distribution is not distributed
when it is packaged unless there is a flag in the `package_data`
argument to setup. This adds that argument.